### PR TITLE
🧪 Add unit tests for Uploader Utilities

### DIFF
--- a/uploader_app/pubspec.lock
+++ b/uploader_app/pubspec.lock
@@ -931,26 +931,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
+      sha256: "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.9"
+    version: "11.0.2"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
+      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.9"
+    version: "3.0.10"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   lints:
     dependency: transitive
     description:
@@ -987,10 +987,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
@@ -1520,26 +1520,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "301b213cd241ca982e9ba50266bd3f5bd1ea33f1455554c5abb85d1be0e2d87e"
+      sha256: "75906bf273541b676716d1ca7627a17e4c4070a3a16272b7a3dc7da3b9f3f6b7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.25.15"
+    version: "1.26.3"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.4"
+    version: "0.7.7"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "84d17c3486c8dfdbe5e12a50c8ae176d15e2a771b96909a9442b40173649ccaa"
+      sha256: "0cc24b5ff94b38d2ae73e1eb43cc302b77964fbf67abad1e296025b78deb53d0"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.8"
+    version: "0.6.12"
   timing:
     dependency: transitive
     description:
@@ -1656,10 +1656,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
   vm_service:
     dependency: transitive
     description:

--- a/uploader_app/test/utils/error_handler_test.dart
+++ b/uploader_app/test/utils/error_handler_test.dart
@@ -1,0 +1,184 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:uploader_app/utils/error_handler.dart';
+
+void main() {
+  group('AppError', () {
+    test('network factory creates correct error', () {
+      final error = AppError.network('Connection failed');
+      expect(error.type, equals(AppErrorType.network));
+      expect(error.message, equals('Connection failed'));
+      expect(error.severity, equals(ErrorSeverity.medium));
+      expect(error.userMessage, equals('Connection issue'));
+      expect(error.context, isNotNull);
+      expect(error.context?['timestamp'], isNotNull);
+    });
+
+    test('authentication factory creates correct error', () {
+      final error = AppError.authentication('Invalid token');
+      expect(error.type, equals(AppErrorType.authentication));
+      expect(error.message, equals('Invalid token'));
+      expect(error.severity, equals(ErrorSeverity.high));
+    });
+
+    test('validation factory creates correct error', () {
+      final error = AppError.validation('Invalid input');
+      expect(error.type, equals(AppErrorType.validation));
+      expect(error.message, equals('Invalid input'));
+      expect(error.severity, equals(ErrorSeverity.low));
+    });
+
+    test('fileSystem factory creates correct error', () {
+      final error = AppError.fileSystem('Cannot read file');
+      expect(error.type, equals(AppErrorType.fileSystem));
+      expect(error.message, equals('Cannot read file'));
+      expect(error.severity, equals(ErrorSeverity.medium));
+    });
+
+    test('camera factory creates correct error', () {
+      final error = AppError.camera('Camera not found');
+      expect(error.type, equals(AppErrorType.camera));
+      expect(error.message, equals('Camera not found'));
+      expect(error.severity, equals(ErrorSeverity.medium));
+    });
+
+    test('upload factory creates correct error', () {
+      final error = AppError.upload('Upload failed', fileName: 'test.jpg');
+      expect(error.type, equals(AppErrorType.upload));
+      expect(error.message, equals('Upload failed'));
+      expect(error.severity, equals(ErrorSeverity.medium));
+      expect(error.context?['file_name'], equals('test.jpg'));
+    });
+
+    test('permission factory creates correct error', () {
+      final error = AppError.permission('Location denied');
+      expect(error.type, equals(AppErrorType.permission));
+      expect(error.message, equals('Location denied'));
+      expect(error.severity, equals(ErrorSeverity.medium));
+    });
+
+    test('generic factory creates correct error', () {
+      final error = AppError.generic('Unknown error');
+      expect(error.type, equals(AppErrorType.unknown));
+      expect(error.message, equals('Unknown error'));
+      expect(error.severity, equals(ErrorSeverity.medium));
+    });
+
+    test('toString returns properly formatted string', () {
+      final error = AppError.generic('Unknown error');
+      expect(
+        error.toString(),
+        equals('AppError(type: AppErrorType.unknown, severity: ErrorSeverity.medium, message: Unknown error)'),
+      );
+    });
+  });
+
+  group('ErrorHandler', () {
+    setUp(() {
+      ErrorHandler.clearErrorHistory();
+    });
+
+    test('handleError adds error to history', () {
+      ErrorHandler.handleError(Exception('Test error'));
+      expect(ErrorHandler.errorHistory.length, equals(1));
+      expect(ErrorHandler.errorHistory.first.message, contains('Test error'));
+    });
+
+    test('handleError maps string patterns to specific error types', () {
+      ErrorHandler.handleError(Exception('network connection failed'));
+      expect(ErrorHandler.errorHistory.last.type, equals(AppErrorType.network));
+
+      ErrorHandler.handleError(Exception('unauthorized access'));
+      expect(ErrorHandler.errorHistory.last.type, equals(AppErrorType.authentication));
+
+      ErrorHandler.handleError(Exception('permission denied'));
+      expect(ErrorHandler.errorHistory.last.type, equals(AppErrorType.permission));
+
+      ErrorHandler.handleError(Exception('camera not found'));
+      expect(ErrorHandler.errorHistory.last.type, equals(AppErrorType.camera));
+
+      ErrorHandler.handleError(Exception('upload timeout'));
+      expect(ErrorHandler.errorHistory.last.type, equals(AppErrorType.upload));
+
+      ErrorHandler.handleError(Exception('something random'));
+      expect(ErrorHandler.errorHistory.last.type, equals(AppErrorType.unknown));
+    });
+
+    test('handleError limits history size', () {
+      for (int i = 0; i < 110; i++) {
+        ErrorHandler.handleError(Exception('Error $i'));
+      }
+      expect(ErrorHandler.errorHistory.length, equals(100));
+      expect(ErrorHandler.errorHistory.last.message, contains('Error 109'));
+    });
+
+    test('errorStream emits errors', () async {
+      final expectedError = AppError.generic('Stream error');
+
+      // Use expectLater to verify stream emissions
+      expectLater(
+        ErrorHandler.errorStream,
+        emitsThrough(isA<AppError>().having((e) => e.message, 'message', 'Stream error')),
+      );
+
+      ErrorHandler.handleError(expectedError);
+    });
+
+    test('getErrorsByType returns filtered errors', () {
+      ErrorHandler.handleError(AppError.network('Net error'));
+      ErrorHandler.handleError(AppError.authentication('Auth error'));
+      ErrorHandler.handleError(AppError.network('Another net error'));
+
+      final netErrors = ErrorHandler.getErrorsByType(AppErrorType.network);
+      expect(netErrors.length, equals(2));
+      expect(netErrors.every((e) => e.type == AppErrorType.network), isTrue);
+    });
+
+    test('getErrorsBySeverity returns filtered errors', () {
+      ErrorHandler.handleError(AppError.validation('Low error')); // low severity
+      ErrorHandler.handleError(AppError.authentication('High error')); // high severity
+
+      final highErrors = ErrorHandler.getErrorsBySeverity(ErrorSeverity.high);
+      expect(highErrors.length, equals(1));
+      expect(highErrors.first.type, equals(AppErrorType.authentication));
+    });
+
+    test('getErrorStats computes correct statistics', () {
+      ErrorHandler.handleError(AppError.network('Net error 1'));
+      ErrorHandler.handleError(AppError.network('Net error 2'));
+      ErrorHandler.handleError(AppError.authentication('Auth error'));
+
+      final stats = ErrorHandler.getErrorStats();
+      expect(stats.totalErrors, equals(3));
+      expect(stats.errorsByType[AppErrorType.network], equals(2));
+      expect(stats.errorsByType[AppErrorType.authentication], equals(1));
+      expect(stats.mostCommonErrorType, equals(AppErrorType.network));
+
+      // Check highest severity (auth = high, network = medium)
+      expect(stats.highestSeverity, equals(ErrorSeverity.high));
+    });
+  });
+
+  group('ErrorStats', () {
+    test('mostCommonErrorType returns null for empty stats', () {
+      const stats = ErrorStats(totalErrors: 0, errorsByType: {}, errorsBySeverity: {});
+      expect(stats.mostCommonErrorType, isNull);
+    });
+
+    test('highestSeverity returns null for empty stats', () {
+      const stats = ErrorStats(totalErrors: 0, errorsByType: {}, errorsBySeverity: {});
+      expect(stats.highestSeverity, isNull);
+    });
+
+    test('toString formats correctly', () {
+      const stats = ErrorStats(
+        totalErrors: 1,
+        errorsByType: {AppErrorType.network: 1},
+        errorsBySeverity: {ErrorSeverity.medium: 1},
+      );
+      expect(
+        stats.toString(),
+        equals('ErrorStats(total: 1, types: {AppErrorType.network: 1}, severities: {ErrorSeverity.medium: 1})'),
+      );
+    });
+  });
+}

--- a/uploader_app/test/utils/logger_test.dart
+++ b/uploader_app/test/utils/logger_test.dart
@@ -1,0 +1,115 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:uploader_app/utils/logger.dart';
+
+void main() {
+  group('Logger', () {
+    test('can configure logger without throwing', () {
+      expect(() {
+        Logger.configure(
+          minimumLevel: LogLevel.debug,
+          enableColors: true,
+          enableStackTrace: true,
+        );
+      }, returnsNormally);
+    });
+
+    test('can log debug message without throwing', () {
+      expect(() {
+        Logger.debug('Debug message', tag: 'TEST');
+      }, returnsNormally);
+    });
+
+    test('can log info message without throwing', () {
+      expect(() {
+        Logger.info('Info message', tag: 'TEST');
+      }, returnsNormally);
+    });
+
+    test('can log warning message without throwing', () {
+      expect(() {
+        Logger.warning('Warning message', tag: 'TEST');
+      }, returnsNormally);
+    });
+
+    test('can log error message with error and stacktrace without throwing', () {
+      expect(() {
+        Logger.error(
+          'Error message',
+          error: Exception('Test exception'),
+          stackTrace: StackTrace.current,
+          tag: 'TEST',
+        );
+      }, returnsNormally);
+    });
+
+    test('can log critical message without throwing', () {
+      expect(() {
+        Logger.critical('Critical message', tag: 'TEST');
+      }, returnsNormally);
+    });
+
+    test('can log HTTP request without throwing', () {
+      expect(() {
+        Logger.logHttpRequest('GET', 'https://example.com/api', headers: {'Authorization': 'Bearer test'});
+      }, returnsNormally);
+
+      expect(() {
+        Logger.logHttpRequest('POST', 'https://example.com/api', body: {'key': 'value'});
+      }, returnsNormally);
+    });
+
+    test('can log HTTP response without throwing', () {
+      expect(() {
+        Logger.logHttpResponse(200, 'https://example.com/api', body: '{"success": true}', duration: const Duration(milliseconds: 150));
+      }, returnsNormally);
+
+      expect(() {
+        Logger.logHttpResponse(404, 'https://example.com/api', duration: const Duration(milliseconds: 50));
+      }, returnsNormally);
+
+      expect(() {
+        Logger.logHttpResponse(500, 'https://example.com/api');
+      }, returnsNormally);
+    });
+
+    test('can log auth event without throwing', () {
+      expect(() {
+        Logger.logAuthEvent('login_success', userId: 'user123', details: 'Method: Email');
+      }, returnsNormally);
+    });
+
+    test('can log upload event without throwing', () {
+      expect(() {
+        Logger.logUploadEvent('upload_start', 'image.jpg', fileSize: 1024 * 1024 * 5, details: 'High res');
+      }, returnsNormally);
+
+      expect(() {
+        Logger.logUploadEvent('upload_complete', 'video.mp4');
+      }, returnsNormally);
+    });
+
+    test('can log user action without throwing', () {
+      expect(() {
+        Logger.logUserAction('click_button', userId: 'user123', details: 'Button: Submit');
+      }, returnsNormally);
+    });
+
+    test('respects log level configuration', () {
+      // It's hard to verify console output easily in simple unit tests without Zones
+      // Here we just ensure changing configuration works
+      Logger.configure(minimumLevel: LogLevel.error);
+
+      // These shouldn't throw, and internally shouldn't log
+      expect(() {
+        Logger.debug('Should not log');
+        Logger.info('Should not log');
+        Logger.warning('Should not log');
+        // This should log
+        Logger.error('Should log');
+      }, returnsNormally);
+
+      // Reset config
+      Logger.configure(minimumLevel: LogLevel.info);
+    });
+  });
+}


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was the missing tests for the core utilities exported by `uploader_app/lib/utils/utils.dart` (`logger.dart` and `error_handler.dart`).
📊 **Coverage:** Scenarios now tested include `AppError` factory constructors, `ErrorHandler` internal history limitations, stream emissions, mapping logic, and computation of `ErrorStats`. Additionally, tests ensure that all `Logger` static methods execute without throwing under different configurations.
✨ **Result:** Test coverage for the core utilities has been significantly improved, ensuring that logging and error handling logic remains reliable through future refactorings.

---
*PR created automatically by Jules for task [9095542194588503619](https://jules.google.com/task/9095542194588503619) started by @njtan142*