### PR TITLE
🧪 test(user_app): improve AuthService testing coverage

### DIFF
--- a/user_app/pubspec.lock
+++ b/user_app/pubspec.lock
@@ -244,26 +244,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
+      sha256: "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.9"
+    version: "11.0.2"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
+      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.9"
+    version: "3.0.10"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   lints:
     dependency: transitive
     description:
@@ -308,10 +308,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   nested:
     dependency: transitive
     description:
@@ -601,10 +601,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.4"
+    version: "0.7.7"
   typed_data:
     dependency: transitive
     description:
@@ -689,10 +689,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
   video_player:
     dependency: "direct main"
     description:

--- a/user_app/test/unit/auth_service_test.dart
+++ b/user_app/test/unit/auth_service_test.dart
@@ -1,28 +1,58 @@
-
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
 import 'package:user_app/services/api_service.dart';
 import 'package:user_app/services/auth_service.dart';
+import 'package:user_app/services/cache_service.dart';
+import 'package:user_app/main.dart'; // Import getIt
 
 // Create a MockApiService using Mockito
 class MockApiService extends Mock implements ApiService {}
+class MockCacheService extends Mock implements CacheService {}
 
 void main() {
   group('AuthService', () {
     late AuthService authService;
     late MockApiService mockApiService;
+    late MockCacheService mockCacheService;
 
     setUp(() {
       mockApiService = MockApiService();
+      mockCacheService = MockCacheService();
+
+      // Register mockCacheService in getIt
+      if (getIt.isRegistered<CacheService>()) {
+        getIt.unregister<CacheService>();
+      }
+      getIt.registerSingleton<CacheService>(mockCacheService);
+
       authService = AuthService(mockApiService);
     });
 
-    test('login returns true on successful authentication', () async {
+    tearDown(() {
+      if (getIt.isRegistered<CacheService>()) {
+        getIt.unregister<CacheService>();
+      }
+    });
+
+    test('isAuthenticated returns true when token is in cache', () {
+      when(mockCacheService.getData('authToken')).thenReturn('some_token');
+      expect(authService.isAuthenticated, isTrue);
+    });
+
+    test('isAuthenticated returns false when token is not in cache', () {
+      when(mockCacheService.getData('authToken')).thenReturn(null);
+      expect(authService.isAuthenticated, isFalse);
+    });
+
+    test('login returns true on successful authentication and saves token', () async {
       when(mockApiService.post('auth/login', any))
           .thenAnswer((_) async => {'token': 'some_token'});
+      when(mockCacheService.saveData('authToken', 'some_token'))
+          .thenAnswer((_) async => true);
 
       final result = await authService.login('testuser', 'password');
       expect(result, true);
+      verify(mockCacheService.saveData('authToken', 'some_token')).called(1);
     });
 
     test('login returns false on failed authentication', () async {
@@ -31,6 +61,7 @@ void main() {
 
       final result = await authService.login('wronguser', 'wrongpass');
       expect(result, false);
+      verifyNever(mockCacheService.saveData(any, any));
     });
 
     test('login returns false on API error', () async {
@@ -39,13 +70,49 @@ void main() {
 
       final result = await authService.login('testuser', 'password');
       expect(result, false);
+      verifyNever(mockCacheService.saveData(any, any));
     });
 
     test('logout performs necessary cleanup', () async {
-      // No specific return value to check for logout, just ensure it runs without error
+      when(mockCacheService.removeData('authToken')).thenAnswer((_) async => true);
+
       await authService.logout();
-      // Verify that no errors occurred
-      verifyNever(mockApiService.post(any, any)); // Ensure no unexpected API calls
+
+      verify(mockCacheService.removeData('authToken')).called(1);
+    });
+
+    test('getToken returns token from cache', () {
+      when(mockCacheService.getData('authToken')).thenReturn('my_cached_token');
+      expect(authService.getToken(), 'my_cached_token');
+    });
+
+    test('getToken returns null if token not in cache', () {
+      when(mockCacheService.getData('authToken')).thenReturn(null);
+      expect(authService.getToken(), isNull);
+    });
+
+    test('register returns true on successful registration', () async {
+      when(mockApiService.post('auth/register', any))
+          .thenAnswer((_) async => {'success': true});
+
+      final result = await authService.register('testuser', 'test@test.com', 'password');
+      expect(result, isTrue);
+    });
+
+    test('register returns false on failed registration', () async {
+      when(mockApiService.post('auth/register', any))
+          .thenAnswer((_) async => {'success': false, 'message': 'Username taken'});
+
+      final result = await authService.register('testuser', 'test@test.com', 'password');
+      expect(result, isFalse);
+    });
+
+    test('register returns false on API error', () async {
+      when(mockApiService.post('auth/register', any))
+          .thenThrow(Exception('Network error'));
+
+      final result = await authService.register('testuser', 'test@test.com', 'password');
+      expect(result, isFalse);
     });
   });
 }


### PR DESCRIPTION
🎯 **What:** The `AuthService` in `user_app` was lacking comprehensive unit testing. The previous tests only loosely covered login and logout without properly mocking the `CacheService` dependency that `AuthService` retrieves from `getIt`. This patch fully mocks dependencies and extends coverage.
📊 **Coverage:** The test suite now explicitly validates:
  - `isAuthenticated`: Check with and without a cached token.
  - `login`: Check success (and cache save), failure, and API errors.
  - `register`: Check success, failure, and API errors.
  - `logout`: Check cache clearance.
  - `getToken`: Verify token retrieval from the cache.
✨ **Result:** The `AuthService` logic is now fully verified by tests ensuring correct integration with `ApiService` and `CacheService`, improving the reliability and maintainability of authentication flows.

---
*PR created automatically by Jules for task [1974931394346549970](https://jules.google.com/task/1974931394346549970) started by @njtan142*