### PR TITLE
feat: Implement infinite scroll pagination for Content Discovery

### DIFF
--- a/user_app/lib/ui/screens/content_discovery_screen.dart
+++ b/user_app/lib/ui/screens/content_discovery_screen.dart
@@ -35,10 +35,9 @@ class _ContentDiscoveryScreenState extends State<ContentDiscoveryScreen> {
       Provider.of<ContentProvider>(context, listen: false).fetchPopularContent();
     });
 
-    // TODO: Implement infinite scroll with actual data fetching
     _scrollController.addListener(() {
       if (_scrollController.position.pixels == _scrollController.position.maxScrollExtent && !Provider.of<ContentProvider>(context, listen: false).isLoading) {
-        // Implement pagination here
+        _loadMoreContent();
       }
     });
   }
@@ -48,6 +47,15 @@ class _ContentDiscoveryScreenState extends State<ContentDiscoveryScreen> {
       query: _searchQuery,
       category: _selectedCategory,
       sortBy: _selectedSortOption,
+    );
+  }
+
+  void _loadMoreContent() {
+    Provider.of<ContentProvider>(context, listen: false).searchContent(
+      query: _searchQuery,
+      category: _selectedCategory,
+      sortBy: _selectedSortOption,
+      isLoadMore: true,
     );
   }
 

--- a/user_app/pubspec.lock
+++ b/user_app/pubspec.lock
@@ -244,26 +244,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
+      sha256: "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.9"
+    version: "11.0.2"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
+      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.9"
+    version: "3.0.10"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   lints:
     dependency: transitive
     description:
@@ -308,10 +308,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   nested:
     dependency: transitive
     description:
@@ -601,10 +601,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.4"
+    version: "0.7.7"
   typed_data:
     dependency: transitive
     description:
@@ -689,10 +689,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
   video_player:
     dependency: "direct main"
     description:


### PR DESCRIPTION
Implemented infinite scroll pagination in `user_app/lib/ui/screens/content_discovery_screen.dart`. Added a `_loadMoreContent` method that calls `searchContent` on the `ContentProvider` with `isLoadMore: true`. Hooked this method up to the existing `ScrollController` listener, ensuring that pagination requests are only triggered when the user reaches the bottom of the scrollable area and the provider is not already loading. This directly implements the requested TO-DO.

---
*PR created automatically by Jules for task [6416531178266986108](https://jules.google.com/task/6416531178266986108) started by @njtan142*