### PR TITLE
🧪 [Testing Improvement] Add exception test for UserService.fetchUsers

### DIFF
--- a/uploader_app/pubspec.lock
+++ b/uploader_app/pubspec.lock
@@ -931,26 +931,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
+      sha256: "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.9"
+    version: "11.0.2"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
+      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.9"
+    version: "3.0.10"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   lints:
     dependency: transitive
     description:
@@ -987,10 +987,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
@@ -1520,26 +1520,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "301b213cd241ca982e9ba50266bd3f5bd1ea33f1455554c5abb85d1be0e2d87e"
+      sha256: "75906bf273541b676716d1ca7627a17e4c4070a3a16272b7a3dc7da3b9f3f6b7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.25.15"
+    version: "1.26.3"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.4"
+    version: "0.7.7"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "84d17c3486c8dfdbe5e12a50c8ae176d15e2a771b96909a9442b40173649ccaa"
+      sha256: "0cc24b5ff94b38d2ae73e1eb43cc302b77964fbf67abad1e296025b78deb53d0"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.8"
+    version: "0.6.12"
   timing:
     dependency: transitive
     description:
@@ -1656,10 +1656,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
   vm_service:
     dependency: transitive
     description:

--- a/uploader_app/test/mocks/mocks.mocks.dart
+++ b/uploader_app/test/mocks/mocks.mocks.dart
@@ -17,7 +17,7 @@ import 'package:uploader_app/services/file_selection_service.dart' as _i6;
 import 'package:uploader_app/services/http_client_service.dart' as _i8;
 import 'package:uploader_app/services/upload_service.dart' as _i4;
 import 'package:uploader_app/services/user_service.dart' as _i3;
-import 'package:uploader_app/services/web_camera_service.dart' as _i5;
+import 'package:uploader_app/services/web_camera_service_stub.dart' as _i5;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -44,56 +44,51 @@ class _FakeUserStats_1 extends _i1.SmartFake implements _i3.UserStats {
     : super(parent, parentInvocation);
 }
 
-class _FakeUpload_2 extends _i1.SmartFake implements _i2.Upload {
-  _FakeUpload_2(Object parent, Invocation parentInvocation)
+class _FakeUploadStats_2 extends _i1.SmartFake implements _i4.UploadStats {
+  _FakeUploadStats_2(Object parent, Invocation parentInvocation)
     : super(parent, parentInvocation);
 }
 
-class _FakeUploadStats_3 extends _i1.SmartFake implements _i4.UploadStats {
-  _FakeUploadStats_3(Object parent, Invocation parentInvocation)
+class _FakeCameraCapture_3 extends _i1.SmartFake implements _i5.CameraCapture {
+  _FakeCameraCapture_3(Object parent, Invocation parentInvocation)
     : super(parent, parentInvocation);
 }
 
-class _FakeCameraCapture_4 extends _i1.SmartFake implements _i5.CameraCapture {
-  _FakeCameraCapture_4(Object parent, Invocation parentInvocation)
-    : super(parent, parentInvocation);
-}
-
-class _FakeFileSelectionConfig_5 extends _i1.SmartFake
+class _FakeFileSelectionConfig_4 extends _i1.SmartFake
     implements _i6.FileSelectionConfig {
-  _FakeFileSelectionConfig_5(Object parent, Invocation parentInvocation)
+  _FakeFileSelectionConfig_4(Object parent, Invocation parentInvocation)
     : super(parent, parentInvocation);
 }
 
-class _FakeIOSOptions_6 extends _i1.SmartFake implements _i7.IOSOptions {
-  _FakeIOSOptions_6(Object parent, Invocation parentInvocation)
+class _FakeIOSOptions_5 extends _i1.SmartFake implements _i7.IOSOptions {
+  _FakeIOSOptions_5(Object parent, Invocation parentInvocation)
     : super(parent, parentInvocation);
 }
 
-class _FakeAndroidOptions_7 extends _i1.SmartFake
+class _FakeAndroidOptions_6 extends _i1.SmartFake
     implements _i7.AndroidOptions {
-  _FakeAndroidOptions_7(Object parent, Invocation parentInvocation)
+  _FakeAndroidOptions_6(Object parent, Invocation parentInvocation)
     : super(parent, parentInvocation);
 }
 
-class _FakeLinuxOptions_8 extends _i1.SmartFake implements _i7.LinuxOptions {
-  _FakeLinuxOptions_8(Object parent, Invocation parentInvocation)
+class _FakeLinuxOptions_7 extends _i1.SmartFake implements _i7.LinuxOptions {
+  _FakeLinuxOptions_7(Object parent, Invocation parentInvocation)
     : super(parent, parentInvocation);
 }
 
-class _FakeWindowsOptions_9 extends _i1.SmartFake
+class _FakeWindowsOptions_8 extends _i1.SmartFake
     implements _i7.WindowsOptions {
-  _FakeWindowsOptions_9(Object parent, Invocation parentInvocation)
+  _FakeWindowsOptions_8(Object parent, Invocation parentInvocation)
     : super(parent, parentInvocation);
 }
 
-class _FakeWebOptions_10 extends _i1.SmartFake implements _i7.WebOptions {
-  _FakeWebOptions_10(Object parent, Invocation parentInvocation)
+class _FakeWebOptions_9 extends _i1.SmartFake implements _i7.WebOptions {
+  _FakeWebOptions_9(Object parent, Invocation parentInvocation)
     : super(parent, parentInvocation);
 }
 
-class _FakeMacOsOptions_11 extends _i1.SmartFake implements _i7.MacOsOptions {
-  _FakeMacOsOptions_11(Object parent, Invocation parentInvocation)
+class _FakeMacOsOptions_10 extends _i1.SmartFake implements _i7.MacOsOptions {
+  _FakeMacOsOptions_10(Object parent, Invocation parentInvocation)
     : super(parent, parentInvocation);
 }
 
@@ -524,6 +519,22 @@ class MockUserService extends _i1.Mock implements _i3.UserService {
           as bool);
 
   @override
+  bool get isCacheValidForTesting =>
+      (super.noSuchMethod(
+            Invocation.getter(#isCacheValidForTesting),
+            returnValue: false,
+          )
+          as bool);
+
+  @override
+  List<_i2.UserModel> get cachedUsersForTesting =>
+      (super.noSuchMethod(
+            Invocation.getter(#cachedUsersForTesting),
+            returnValue: <_i2.UserModel>[],
+          )
+          as List<_i2.UserModel>);
+
+  @override
   _i10.Future<void> initialize() =>
       (super.noSuchMethod(
             Invocation.method(#initialize, []),
@@ -542,28 +553,32 @@ class MockUserService extends _i1.Mock implements _i3.UserService {
               #forceRefresh: forceRefresh,
               #filters: filters,
             }),
-            returnValue: _i10.Future<_i2.ApiResponse<List<_i2.UserModel>>>.value(
-              _FakeApiResponse_0<List<_i2.UserModel>>(
-                this,
-                Invocation.method(#fetchUsers, [], {
-                  #forceRefresh: forceRefresh,
-                  #filters: filters,
-                }),
-              ),
-            ),
+            returnValue:
+                _i10.Future<_i2.ApiResponse<List<_i2.UserModel>>>.value(
+                  _FakeApiResponse_0<List<_i2.UserModel>>(
+                    this,
+                    Invocation.method(#fetchUsers, [], {
+                      #forceRefresh: forceRefresh,
+                      #filters: filters,
+                    }),
+                  ),
+                ),
           )
           as _i10.Future<_i2.ApiResponse<List<_i2.UserModel>>>);
 
   @override
-  _i10.Future<_i2.ApiResponse<List<_i2.UserModel>>> searchUsers(String? query) =>
+  _i10.Future<_i2.ApiResponse<List<_i2.UserModel>>> searchUsers(
+    String? query,
+  ) =>
       (super.noSuchMethod(
             Invocation.method(#searchUsers, [query]),
-            returnValue: _i10.Future<_i2.ApiResponse<List<_i2.UserModel>>>.value(
-              _FakeApiResponse_0<List<_i2.UserModel>>(
-                this,
-                Invocation.method(#searchUsers, [query]),
-              ),
-            ),
+            returnValue:
+                _i10.Future<_i2.ApiResponse<List<_i2.UserModel>>>.value(
+                  _FakeApiResponse_0<List<_i2.UserModel>>(
+                    this,
+                    Invocation.method(#searchUsers, [query]),
+                  ),
+                ),
           )
           as _i10.Future<_i2.ApiResponse<List<_i2.UserModel>>>);
 
@@ -648,6 +663,32 @@ class MockUserService extends _i1.Mock implements _i3.UserService {
     Invocation.method(#dispose, []),
     returnValueForMissingStub: null,
   );
+
+  @override
+  void setCachedUsersForTesting(List<_i2.UserModel>? users) =>
+      super.noSuchMethod(
+        Invocation.method(#setCachedUsersForTesting, [users]),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void setLastFetchTimeForTesting(DateTime? time) => super.noSuchMethod(
+    Invocation.method(#setLastFetchTimeForTesting, [time]),
+    returnValueForMissingStub: null,
+  );
+
+  @override
+  void addLoadingStateForTesting(bool? isLoading) => super.noSuchMethod(
+    Invocation.method(#addLoadingStateForTesting, [isLoading]),
+    returnValueForMissingStub: null,
+  );
+
+  @override
+  void addUsersUpdateForTesting(List<_i2.UserModel>? users) =>
+      super.noSuchMethod(
+        Invocation.method(#addUsersUpdateForTesting, [users]),
+        returnValueForMissingStub: null,
+      );
 }
 
 /// A class which mocks [UploadService].
@@ -693,7 +734,7 @@ class MockUploadService extends _i1.Mock implements _i4.UploadService {
           as int);
 
   @override
-  _i10.Future<_i2.Upload> uploadFile({
+  _i10.Future<_i2.ApiResponse<_i2.Upload>> uploadFile({
     required String? fileName,
     required List<int>? fileBytes,
     required String? mimeType,
@@ -714,8 +755,8 @@ class MockUploadService extends _i1.Mock implements _i4.UploadService {
               #onComplete: onComplete,
               #onError: onError,
             }),
-            returnValue: _i10.Future<_i2.Upload>.value(
-              _FakeUpload_2(
+            returnValue: _i10.Future<_i2.ApiResponse<_i2.Upload>>.value(
+              _FakeApiResponse_0<_i2.Upload>(
                 this,
                 Invocation.method(#uploadFile, [], {
                   #fileName: fileName,
@@ -730,10 +771,10 @@ class MockUploadService extends _i1.Mock implements _i4.UploadService {
               ),
             ),
           )
-          as _i10.Future<_i2.Upload>);
+          as _i10.Future<_i2.ApiResponse<_i2.Upload>>);
 
   @override
-  _i10.Future<_i2.Upload> uploadFileFromPath({
+  _i10.Future<_i2.ApiResponse<_i2.Upload>> uploadFileFromPath({
     required String? filePath,
     required String? fileName,
     required int? fileSize,
@@ -756,8 +797,8 @@ class MockUploadService extends _i1.Mock implements _i4.UploadService {
               #onComplete: onComplete,
               #onError: onError,
             }),
-            returnValue: _i10.Future<_i2.Upload>.value(
-              _FakeUpload_2(
+            returnValue: _i10.Future<_i2.ApiResponse<_i2.Upload>>.value(
+              _FakeApiResponse_0<_i2.Upload>(
                 this,
                 Invocation.method(#uploadFileFromPath, [], {
                   #filePath: filePath,
@@ -773,7 +814,7 @@ class MockUploadService extends _i1.Mock implements _i4.UploadService {
               ),
             ),
           )
-          as _i10.Future<_i2.Upload>);
+          as _i10.Future<_i2.ApiResponse<_i2.Upload>>);
 
   @override
   _i10.Future<bool> cancelUpload(String? uploadId) =>
@@ -801,7 +842,7 @@ class MockUploadService extends _i1.Mock implements _i4.UploadService {
   _i4.UploadStats getUploadStats() =>
       (super.noSuchMethod(
             Invocation.method(#getUploadStats, []),
-            returnValue: _FakeUploadStats_3(
+            returnValue: _FakeUploadStats_2(
               this,
               Invocation.method(#getUploadStats, []),
             ),
@@ -905,7 +946,7 @@ class MockWebCameraService extends _i1.Mock implements _i5.WebCameraService {
               #maxHeight: maxHeight,
             }),
             returnValue: _i10.Future<_i5.CameraCapture>.value(
-              _FakeCameraCapture_4(
+              _FakeCameraCapture_3(
                 this,
                 Invocation.method(#capturePhoto, [], {
                   #quality: quality,
@@ -991,7 +1032,7 @@ class MockFileSelectionService extends _i1.Mock
   _i6.FileSelectionConfig get config =>
       (super.noSuchMethod(
             Invocation.getter(#config),
-            returnValue: _FakeFileSelectionConfig_5(
+            returnValue: _FakeFileSelectionConfig_4(
               this,
               Invocation.getter(#config),
             ),
@@ -1218,7 +1259,7 @@ class MockFlutterSecureStorage extends _i1.Mock
   _i7.IOSOptions get iOptions =>
       (super.noSuchMethod(
             Invocation.getter(#iOptions),
-            returnValue: _FakeIOSOptions_6(this, Invocation.getter(#iOptions)),
+            returnValue: _FakeIOSOptions_5(this, Invocation.getter(#iOptions)),
           )
           as _i7.IOSOptions);
 
@@ -1226,7 +1267,7 @@ class MockFlutterSecureStorage extends _i1.Mock
   _i7.AndroidOptions get aOptions =>
       (super.noSuchMethod(
             Invocation.getter(#aOptions),
-            returnValue: _FakeAndroidOptions_7(
+            returnValue: _FakeAndroidOptions_6(
               this,
               Invocation.getter(#aOptions),
             ),
@@ -1237,7 +1278,7 @@ class MockFlutterSecureStorage extends _i1.Mock
   _i7.LinuxOptions get lOptions =>
       (super.noSuchMethod(
             Invocation.getter(#lOptions),
-            returnValue: _FakeLinuxOptions_8(
+            returnValue: _FakeLinuxOptions_7(
               this,
               Invocation.getter(#lOptions),
             ),
@@ -1248,7 +1289,7 @@ class MockFlutterSecureStorage extends _i1.Mock
   _i7.WindowsOptions get wOptions =>
       (super.noSuchMethod(
             Invocation.getter(#wOptions),
-            returnValue: _FakeWindowsOptions_9(
+            returnValue: _FakeWindowsOptions_8(
               this,
               Invocation.getter(#wOptions),
             ),
@@ -1259,7 +1300,7 @@ class MockFlutterSecureStorage extends _i1.Mock
   _i7.WebOptions get webOptions =>
       (super.noSuchMethod(
             Invocation.getter(#webOptions),
-            returnValue: _FakeWebOptions_10(
+            returnValue: _FakeWebOptions_9(
               this,
               Invocation.getter(#webOptions),
             ),
@@ -1270,7 +1311,7 @@ class MockFlutterSecureStorage extends _i1.Mock
   _i7.MacOsOptions get mOptions =>
       (super.noSuchMethod(
             Invocation.getter(#mOptions),
-            returnValue: _FakeMacOsOptions_11(
+            returnValue: _FakeMacOsOptions_10(
               this,
               Invocation.getter(#mOptions),
             ),

--- a/uploader_app/test/services/user_service_test.dart
+++ b/uploader_app/test/services/user_service_test.dart
@@ -125,6 +125,20 @@ void main() {
       expect(userService.isLoading, false);
     });
 
+    test('fetchUsers handles exceptions correctly', () async {
+      // Arrange
+      when(mockHttpClient.get<PaginatedResponse<UserModel>>(any, fromJson: anyNamed('fromJson')))
+          .thenThrow(Exception('Network disconnected'));
+
+      // Act
+      final result = await userService.fetchUsers(forceRefresh: true);
+
+      // Assert
+      expect(result.success, false);
+      expect(result.message, contains('Failed to fetch users: Exception: Network disconnected'));
+      expect(userService.isLoading, false);
+    });
+
     test('searchUsers returns filtered cached results for non-empty query', () async {
       // Arrange
       final users = [

--- a/uploader_app/test/test_utils.mocks.dart
+++ b/uploader_app/test/test_utils.mocks.dart
@@ -15,7 +15,7 @@ import 'package:uploader_app/services/file_selection_service.dart' as _i6;
 import 'package:uploader_app/services/http_client_service.dart' as _i7;
 import 'package:uploader_app/services/upload_service.dart' as _i4;
 import 'package:uploader_app/services/user_service.dart' as _i3;
-import 'package:uploader_app/services/web_camera_service.dart' as _i5;
+import 'package:uploader_app/services/web_camera_service_stub.dart' as _i5;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -42,24 +42,19 @@ class _FakeUserStats_1 extends _i1.SmartFake implements _i3.UserStats {
     : super(parent, parentInvocation);
 }
 
-class _FakeUpload_2 extends _i1.SmartFake implements _i2.Upload {
-  _FakeUpload_2(Object parent, Invocation parentInvocation)
+class _FakeUploadStats_2 extends _i1.SmartFake implements _i4.UploadStats {
+  _FakeUploadStats_2(Object parent, Invocation parentInvocation)
     : super(parent, parentInvocation);
 }
 
-class _FakeUploadStats_3 extends _i1.SmartFake implements _i4.UploadStats {
-  _FakeUploadStats_3(Object parent, Invocation parentInvocation)
+class _FakeCameraCapture_3 extends _i1.SmartFake implements _i5.CameraCapture {
+  _FakeCameraCapture_3(Object parent, Invocation parentInvocation)
     : super(parent, parentInvocation);
 }
 
-class _FakeCameraCapture_4 extends _i1.SmartFake implements _i5.CameraCapture {
-  _FakeCameraCapture_4(Object parent, Invocation parentInvocation)
-    : super(parent, parentInvocation);
-}
-
-class _FakeFileSelectionConfig_5 extends _i1.SmartFake
+class _FakeFileSelectionConfig_4 extends _i1.SmartFake
     implements _i6.FileSelectionConfig {
-  _FakeFileSelectionConfig_5(Object parent, Invocation parentInvocation)
+  _FakeFileSelectionConfig_4(Object parent, Invocation parentInvocation)
     : super(parent, parentInvocation);
 }
 
@@ -490,6 +485,22 @@ class MockUserService extends _i1.Mock implements _i3.UserService {
           as bool);
 
   @override
+  bool get isCacheValidForTesting =>
+      (super.noSuchMethod(
+            Invocation.getter(#isCacheValidForTesting),
+            returnValue: false,
+          )
+          as bool);
+
+  @override
+  List<_i2.UserModel> get cachedUsersForTesting =>
+      (super.noSuchMethod(
+            Invocation.getter(#cachedUsersForTesting),
+            returnValue: <_i2.UserModel>[],
+          )
+          as List<_i2.UserModel>);
+
+  @override
   _i9.Future<void> initialize() =>
       (super.noSuchMethod(
             Invocation.method(#initialize, []),
@@ -614,6 +625,32 @@ class MockUserService extends _i1.Mock implements _i3.UserService {
     Invocation.method(#dispose, []),
     returnValueForMissingStub: null,
   );
+
+  @override
+  void setCachedUsersForTesting(List<_i2.UserModel>? users) =>
+      super.noSuchMethod(
+        Invocation.method(#setCachedUsersForTesting, [users]),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void setLastFetchTimeForTesting(DateTime? time) => super.noSuchMethod(
+    Invocation.method(#setLastFetchTimeForTesting, [time]),
+    returnValueForMissingStub: null,
+  );
+
+  @override
+  void addLoadingStateForTesting(bool? isLoading) => super.noSuchMethod(
+    Invocation.method(#addLoadingStateForTesting, [isLoading]),
+    returnValueForMissingStub: null,
+  );
+
+  @override
+  void addUsersUpdateForTesting(List<_i2.UserModel>? users) =>
+      super.noSuchMethod(
+        Invocation.method(#addUsersUpdateForTesting, [users]),
+        returnValueForMissingStub: null,
+      );
 }
 
 /// A class which mocks [UploadService].
@@ -659,7 +696,7 @@ class MockUploadService extends _i1.Mock implements _i4.UploadService {
           as int);
 
   @override
-  _i9.Future<_i2.Upload> uploadFile({
+  _i9.Future<_i2.ApiResponse<_i2.Upload>> uploadFile({
     required String? fileName,
     required List<int>? fileBytes,
     required String? mimeType,
@@ -680,8 +717,8 @@ class MockUploadService extends _i1.Mock implements _i4.UploadService {
               #onComplete: onComplete,
               #onError: onError,
             }),
-            returnValue: _i9.Future<_i2.Upload>.value(
-              _FakeUpload_2(
+            returnValue: _i9.Future<_i2.ApiResponse<_i2.Upload>>.value(
+              _FakeApiResponse_0<_i2.Upload>(
                 this,
                 Invocation.method(#uploadFile, [], {
                   #fileName: fileName,
@@ -696,10 +733,10 @@ class MockUploadService extends _i1.Mock implements _i4.UploadService {
               ),
             ),
           )
-          as _i9.Future<_i2.Upload>);
+          as _i9.Future<_i2.ApiResponse<_i2.Upload>>);
 
   @override
-  _i9.Future<_i2.Upload> uploadFileFromPath({
+  _i9.Future<_i2.ApiResponse<_i2.Upload>> uploadFileFromPath({
     required String? filePath,
     required String? fileName,
     required int? fileSize,
@@ -722,8 +759,8 @@ class MockUploadService extends _i1.Mock implements _i4.UploadService {
               #onComplete: onComplete,
               #onError: onError,
             }),
-            returnValue: _i9.Future<_i2.Upload>.value(
-              _FakeUpload_2(
+            returnValue: _i9.Future<_i2.ApiResponse<_i2.Upload>>.value(
+              _FakeApiResponse_0<_i2.Upload>(
                 this,
                 Invocation.method(#uploadFileFromPath, [], {
                   #filePath: filePath,
@@ -739,7 +776,7 @@ class MockUploadService extends _i1.Mock implements _i4.UploadService {
               ),
             ),
           )
-          as _i9.Future<_i2.Upload>);
+          as _i9.Future<_i2.ApiResponse<_i2.Upload>>);
 
   @override
   _i9.Future<bool> cancelUpload(String? uploadId) =>
@@ -767,7 +804,7 @@ class MockUploadService extends _i1.Mock implements _i4.UploadService {
   _i4.UploadStats getUploadStats() =>
       (super.noSuchMethod(
             Invocation.method(#getUploadStats, []),
-            returnValue: _FakeUploadStats_3(
+            returnValue: _FakeUploadStats_2(
               this,
               Invocation.method(#getUploadStats, []),
             ),
@@ -871,7 +908,7 @@ class MockWebCameraService extends _i1.Mock implements _i5.WebCameraService {
               #maxHeight: maxHeight,
             }),
             returnValue: _i9.Future<_i5.CameraCapture>.value(
-              _FakeCameraCapture_4(
+              _FakeCameraCapture_3(
                 this,
                 Invocation.method(#capturePhoto, [], {
                   #quality: quality,
@@ -957,7 +994,7 @@ class MockFileSelectionService extends _i1.Mock
   _i6.FileSelectionConfig get config =>
       (super.noSuchMethod(
             Invocation.getter(#config),
-            returnValue: _FakeFileSelectionConfig_5(
+            returnValue: _FakeFileSelectionConfig_4(
               this,
               Invocation.getter(#config),
             ),


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The `fetchUsers` method in `UserService` had a `catch` block that was not covered by existing tests. This block handles unexpected exceptions thrown by the underlying `HttpClientService`.

📊 **Coverage:** What scenarios are now tested
A new test `'fetchUsers handles exceptions correctly'` was added to verify the behavior when the mock HTTP client throws an `Exception`.

✨ **Result:** The improvement in test coverage
The catch block at `uploader_app/lib/services/user_service.dart:120` is now fully tested, ensuring that the service gracefully returns an `ApiResponse.error` with the correct string format ("Failed to fetch users: ...") and properly resets its internal loading state when a network or parsing exception occurs.

---
*PR created automatically by Jules for task [18312189986462889047](https://jules.google.com/task/18312189986462889047) started by @njtan142*