### PR TITLE
🧪 [AnalyticsService] Add initialization error test

### DIFF
--- a/uploader_app/lib/services/analytics_service.dart
+++ b/uploader_app/lib/services/analytics_service.dart
@@ -8,9 +8,11 @@ import '../config/environment_config.dart';
 
 /// Analytics and Monitoring Service for the Plantita Uploader app
 class AnalyticsService {
-  static final AnalyticsService _instance = AnalyticsService._internal();
+  static final AnalyticsService _instance = AnalyticsService.internal();
   factory AnalyticsService() => _instance;
-  AnalyticsService._internal();
+
+  @visibleForTesting
+  AnalyticsService.internal();
 
   // Firebase instances
   FirebaseAnalytics? _analytics;
@@ -29,25 +31,35 @@ class AnalyticsService {
   bool get isEnabled => _isEnabled && EnvironmentConfig.enableAnalytics;
   FirebaseAnalytics? get analytics => _analytics;
 
+  @visibleForTesting
+  bool get shouldInitialize => kIsWeb && EnvironmentConfig.enableAnalytics;
+
+  @visibleForTesting
+  Future<void> initFirebase() async {
+    await _initializeFirebaseAnalytics();
+    await _initializeCrashlytics();
+    await _initializePerformanceMonitoring();
+  }
+
   /// Initialize analytics and monitoring services
-  Future<void> initialize() async {
-    if (!kIsWeb || !EnvironmentConfig.enableAnalytics) {
+  Future<bool> initialize() async {
+    if (!shouldInitialize) {
       debugPrint('Analytics: Disabled or not running on web platform');
-      return;
+      return false;
     }
 
     try {
-      await _initializeFirebaseAnalytics();
-      await _initializeCrashlytics();
-      await _initializePerformanceMonitoring();
+      await initFirebase();
 
       _isInitialized = true;
       _isEnabled = true;
 
       debugPrint('Analytics: Initialized successfully');
+      return true;
     } catch (e) {
       debugPrint('Analytics: Initialization failed: $e');
       _isEnabled = false;
+      return false;
     }
   }
 

--- a/uploader_app/pubspec.lock
+++ b/uploader_app/pubspec.lock
@@ -931,26 +931,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
+      sha256: "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.9"
+    version: "11.0.2"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
+      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.9"
+    version: "3.0.10"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   lints:
     dependency: transitive
     description:
@@ -987,10 +987,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
@@ -1520,26 +1520,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "301b213cd241ca982e9ba50266bd3f5bd1ea33f1455554c5abb85d1be0e2d87e"
+      sha256: "75906bf273541b676716d1ca7627a17e4c4070a3a16272b7a3dc7da3b9f3f6b7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.25.15"
+    version: "1.26.3"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.4"
+    version: "0.7.7"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "84d17c3486c8dfdbe5e12a50c8ae176d15e2a771b96909a9442b40173649ccaa"
+      sha256: "0cc24b5ff94b38d2ae73e1eb43cc302b77964fbf67abad1e296025b78deb53d0"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.8"
+    version: "0.6.12"
   timing:
     dependency: transitive
     description:
@@ -1656,10 +1656,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
   vm_service:
     dependency: transitive
     description:

--- a/uploader_app/test/services/analytics_service_test.dart
+++ b/uploader_app/test/services/analytics_service_test.dart
@@ -1,0 +1,31 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:uploader_app/services/analytics_service.dart';
+
+class TestAnalyticsService extends AnalyticsService {
+  TestAnalyticsService() : super.internal();
+
+  @override
+  bool get shouldInitialize => true;
+
+  @override
+  Future<void> initFirebase() async {
+    throw Exception('Mock Error');
+  }
+}
+
+void main() {
+  group('AnalyticsService Tests', () {
+    test('initialization catches errors, returns false, and sets isEnabled to false', () async {
+      // Arrange
+      final service = TestAnalyticsService();
+
+      // Act
+      final result = await service.initialize();
+
+      // Assert
+      expect(result, isFalse, reason: 'Expected initialize to return false on error');
+      expect(service.isEnabled, isFalse, reason: 'Expected isEnabled to be false after failure');
+      expect(service.isInitialized, isFalse, reason: 'Expected isInitialized to remain false');
+    });
+  });
+}


### PR DESCRIPTION
🎯 **What:** The `AnalyticsService.initialize()` method was missing tests for its error handling path.
📊 **Coverage:** A new test now covers the scenario where Firebase initialization throws an exception, verifying that the `catch` block correctly captures the error, prevents the app from crashing, and sets `isEnabled` to false.
✨ **Result:** Increased test coverage and confidence that failures in analytics initialization will not negatively impact the application's startup flow. The service was also refactored using an 'Extract and Override' approach to allow proper testing without test-induced design damage.

---
*PR created automatically by Jules for task [13535141131899473527](https://jules.google.com/task/13535141131899473527) started by @njtan142*